### PR TITLE
source code background color

### DIFF
--- a/github.css
+++ b/github.css
@@ -483,8 +483,11 @@ body pre {
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
-  background-color: #f7f7f7;
   border-radius: 3px;
+}
+
+.sourceCode {
+  background-color: #f7f7f7;
 }
 
 body .highlight pre {

--- a/github.css
+++ b/github.css
@@ -483,6 +483,7 @@ body pre {
   overflow: auto;
   font-size: 85%;
   line-height: 1.45;
+  background-color: #f7f7f7;
   border-radius: 3px;
 }
 


### PR DESCRIPTION
adjust the background color for source code. When the source code cell is to large, the outside of default visible zone is white in background.